### PR TITLE
Fix default workspace typo

### DIFF
--- a/home/ui/default.nix
+++ b/home/ui/default.nix
@@ -237,7 +237,7 @@ in {
       monitor=Unknown-1,disable
 
       workspace=1,monitor:desc:${monitorLeft.desc},default:true
-      workspace=2,monitor:desc:${monitorCentre.desc},defualt:true
+      workspace=2,monitor:desc:${monitorCentre.desc},default:true
       workspace=3,monitor:desc:${monitorRight.desc},default:true
 
       # Key bindings


### PR DESCRIPTION
## Summary
- fix 'defualt' typo when assigning monitor workspace in Hyprland config

## Testing
- `nix flake show` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fee775d388327b30da04e022eb4e0