### PR TITLE
Add blink-ripgrep provider

### DIFF
--- a/home/vim/plugins/auto-completion.nix
+++ b/home/vim/plugins/auto-completion.nix
@@ -1,6 +1,6 @@
 pkgs: {
   blink-cmp-spell.enable = true;
-  blink-ripgre.enable = true;
+  blink-ripgrep.enable = true;
   blink-cmp = let
     border_type = "rounded";
   in {


### PR DESCRIPTION
## Summary
- enable `blink-ripgrep-nvim`
- set up `ripgrep` as a provider using documented defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684000af9c0483278792b9b6e971b845