### PR TITLE
Update blink.cmp theme integration

### DIFF
--- a/home/vim/default.nix
+++ b/home/vim/default.nix
@@ -44,7 +44,11 @@ in {
         local kanagawa_background = "#1f1f28"
 
         -- Set up floating window appearance
-        vim.api.nvim_set_hl(0, "FloatBorder", { bg = kanagawa_background})  -- Match the border background with kanagawa
+        vim.api.nvim_set_hl(0, "FloatBorder", { bg = kanagawa_background })  -- Match the border background with kanagawa
+        -- Ensure blink.cmp windows match the colorscheme
+        vim.api.nvim_set_hl(0, "BlinkCmpMenuBorder", { bg = kanagawa_background, fg = kanagawa_background })
+        vim.api.nvim_set_hl(0, "BlinkCmpDocBorder", { link = "FloatBorder" })
+        vim.api.nvim_set_hl(0, "BlinkCmpSignatureHelpBorder", { link = "FloatBorder" })
 
         vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
             vim.lsp.handlers.hover, {

--- a/home/vim/plugins/auto-completion.nix
+++ b/home/vim/plugins/auto-completion.nix
@@ -9,7 +9,9 @@ pkgs: {
     settings = {
       appearance = {
         nerd_font_variant = "normal";
-        use_nvim_cmp_as_default = true;
+        # Use highlight groups provided by the current colorscheme
+        # instead of falling back to nvim-cmp defaults.
+        use_nvim_cmp_as_default = false;
       };
       completion = {
         accept = {


### PR DESCRIPTION
## Summary
- ensure blink.cmp uses scheme-provided highlights
- adjust float borders for blink.cmp windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a49993d08327878d9042861c706b