### PR TITLE
Use unstable avante plugin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
       url = "nixpkgs/nixos-25.05";
     };
 
+    unstable = {
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+
     nix-darwin = {
       url = "github:LnL7/nix-darwin/nix-darwin-25.05";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/overlays/nixvim-avante.nix
+++ b/overlays/nixvim-avante.nix
@@ -1,0 +1,6 @@
+{ unstable }:
+self: super: {
+  vimPlugins = super.vimPlugins // {
+    avante-nvim = unstable.legacyPackages.${super.system}.vimPlugins.avante-nvim;
+  };
+}

--- a/utils/mkSystem.nix
+++ b/utils/mkSystem.nix
@@ -36,6 +36,7 @@
 
   sharedOverlays = [
     inputs.fenix.overlays.default
+    (import ../overlays/nixvim-avante.nix { unstable = inputs.unstable; })
   ];
 in {
   nixos = {


### PR DESCRIPTION
## Summary
- pull `avante-nvim` from `nixpkgs-unstable`
- add overlay applying this plugin override on all systems

## Testing
- `nix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433b4399d48327898bee0cb590bd14