### PR TITLE
Fix warnings with home-manager and increase Nix download buffer

### DIFF
--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -273,4 +273,5 @@ in {
 
   system.stateVersion = "23.11"; # Did you read the comment? (doesn't need to change?)
   nix.settings.experimental-features = ["nix-command" "flakes"];
+  nix.settings.download-buffer-size = 33554432; # 32MiB
 }

--- a/hosts/mac/configuration.nix
+++ b/hosts/mac/configuration.nix
@@ -13,6 +13,7 @@ in {
   nix.enable = true;
   users.users.harryp.home = lib.mkForce homeDir;
   nix.settings.experimental-features = "nix-command flakes";
+  nix.settings.download-buffer-size = 33554432; # 32MiB
   nix.extraOptions = ''
     extra-platforms = x86_64-darwin aarch64-darwin
   '';

--- a/utils/mkSystem.nix
+++ b/utils/mkSystem.nix
@@ -58,7 +58,6 @@ in {
       };
       modules = [
         sysConfig
-        home-manager.nixosModules.home-manager
         {
           nixpkgs.config.permittedInsecurePackages = permittedInsecurePkgs;
           nixpkgs.overlays =
@@ -67,6 +66,9 @@ in {
               (inputs.ghostty.overlays.default)
             ]
             ++ sharedOverlays;
+        }
+        home-manager.nixosModules.home-manager
+        {
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.users.harryp.imports = [homeConfig];
@@ -106,10 +108,12 @@ in {
       modules = [
         sysConfig
         inputs.mac-app-util.darwinModules.default
-        inputs.home-manager.darwinModules.home-manager
         {
           nixpkgs.config.permittedInsecurePackages = permittedInsecurePkgs;
           nixpkgs.overlays = [] ++ sharedOverlays;
+        }
+        inputs.home-manager.darwinModules.home-manager
+        {
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.users.harryp.imports = [homeConfig];


### PR DESCRIPTION
## Summary
- avoid setting nixpkgs options in the same module that enables `home-manager.useGlobalPkgs`
- bump Nix `download-buffer-size` on Linux and macOS hosts

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake show`
- `nix --extra-experimental-features 'nix-command flakes' build --dry-run .#nixosConfigurations.nixos.config.system.build.toplevel` *(fails: unable to download from cache.nixos.org)*

------
https://chatgpt.com/codex/tasks/task_e_68514be4af1c832782f79f36a2d3b023